### PR TITLE
Add different URL for metrics/measurements and agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Role Variables
 | appoptics_task_path | /opt/SolarWinds/Snap/etc/tasks.d | Search path for task file. |
 | appoptics_plugins_include | /opt/SolarWinds/Snap/etc/plugins.d | Search path for plugin configuration files. |
 | appoptics_token | "" | Sets the appoptics authentication token. |
-| appoptics_url | https://api.appoptics.com/v1/measurements | Sets the appoptics endpoint. |
+| appoptics_metrics_url | https://api.appoptics.com/v1/measurements | Sets the appoptics metrics endpoint. |
+| appoptics_agent_url | https://api.appoptics.com/v1/agent/report | Sets the appoptics agent endpoint. |
 | appoptics_hostname_alias | "" | Sets a hostname alias if you want want a different host tag than the current hostname of the host. |
 | appoptics_proxy_url | "" | Sets the proxy url. |
 | appoptics_proxy_user | "" | Sets the user for authenticating against the proxy configured in 'proxy url' field. |
@@ -70,7 +71,7 @@ Example Playbook
     - hosts: servers
       vars:
         appoptics_token: secretoken123abc
-        appoptics_url: https://api.appoptics.com/v1/measurements
+        appoptics_metrics_url: https://api.appoptics.com/v1/measurements
         appoptics_hostname_alias: hostname-01
         appoptics_proxy_url: https://192.168.0.1:8080
         appoptics_proxy_user: user

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,7 +26,8 @@ appoptics_task_path: /opt/SolarWinds/Snap/etc/tasks.d
 appoptics_plugins_include: /opt/SolarWinds/Snap/etc/plugins.d
 
 appoptics_token: ""
-appoptics_url: https://api.appoptics.com/v1/measurements
+appoptics_metrics_url: https://api.appoptics.com/v1/measurements
+appoptics_agent_url: https://api.appoptics.com/v1/agent/report
 appoptics_hostname_alias: ""
 appoptics_proxy_url: ""
 appoptics_proxy_user: ""

--- a/molecule/basic_configuration/playbook.yml
+++ b/molecule/basic_configuration/playbook.yml
@@ -3,7 +3,7 @@
   hosts: all
   vars:
     appoptics_token: secretoken123abc
-    appoptics_url: https://api.appoptics.com/v1/measurements
+    appoptics_metrics_url: https://api.appoptics.com/v1/measurements
     appoptics_hostname_alias: hostname-01
     appoptics_proxy_url: https://192.168.0.1:8080
     appoptics_proxy_user: user

--- a/molecule/plugins_configuration/playbook.yml
+++ b/molecule/plugins_configuration/playbook.yml
@@ -3,7 +3,7 @@
   hosts: all
   vars:
     appoptics_token: secretoken123abc
-    appoptics_url: https://api.appoptics.com/v1/measurements
+    appoptics_metrics_url: https://api.appoptics.com/v1/measurements
     appoptics_hostname_alias: hostname-01
     appoptics_proxy_url: https://192.168.0.1:8080
     appoptics_proxy_user: user

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -39,7 +39,7 @@ control:
     publisher:
       publisher-appoptics:
         all:
-          url: {{ appoptics_url }}
+          url: {{ appoptics_metrics_url }}
           token: "{{ appoptics_token }}"
           {% if appoptics_hostname_alias | length %}
           hostname_alias: {{ appoptics_hostname_alias }}
@@ -58,7 +58,7 @@ control:
           {% endif %}
       publisher-processes:
         all:
-          url: {{ appoptics_url }}
+          url: {{ appoptics_agent_url }}
           token: "{{ appoptics_token }}"
 
   {% if appoptics_global_tags is defined and appoptics_global_tags is mapping and appoptics_global_tags | length %}


### PR DESCRIPTION
While testing the role, I noticed that the Agent did not report process information to the AppOptics. Seems that they are using different URL for metrics and agent data, while the template uses same URL for both. This PR should address the issue.